### PR TITLE
Make path handling more robust

### DIFF
--- a/source/assets/map/MapListLoader.cpp
+++ b/source/assets/map/MapListLoader.cpp
@@ -10,7 +10,7 @@ namespace glPortal {
 
 vector<string> MapListLoader::getMapList() {
   vector<string> mapList;
-  std::string path = Environment::getDataDir() + "maps/maplist";
+  std::string path = Environment::getDataDir() + "/maps/maplist";
   ifstream file(path);
 
   if(not file.is_open()) {

--- a/source/assets/map/MapLoader.cpp
+++ b/source/assets/map/MapLoader.cpp
@@ -38,7 +38,7 @@ namespace glPortal {
 Scene* MapLoader::getScene(std::string path) {
   scene = new Scene();
 
-  TiXmlDocument doc(string(Environment::getDataDir() + "maps/" + path + ".xml"));
+  TiXmlDocument doc(string(Environment::getDataDir() + "/maps/" + path + ".xml"));
   bool loaded = doc.LoadFile();
 
   if (loaded) {
@@ -57,7 +57,7 @@ Scene* MapLoader::getScene(std::string path) {
     cout << "File loaded." << endl;
   } else {
     cout << "Unable to load file. " << endl;
-    cout << string(Environment::getDataDir()) << path << endl;
+    cout << string(Environment::getDataDir()) << "/" << path << ".xml" << endl;
   }
   return scene;
 }

--- a/source/assets/model/MeshLoader.cpp
+++ b/source/assets/model/MeshLoader.cpp
@@ -20,7 +20,7 @@ namespace glPortal {
 std::map<std::string, Mesh> MeshLoader::meshCache = { };
 
 Mesh MeshLoader::getMesh(std::string path) {
-  path = Environment::getDataDir() + "meshes/" + path;
+  path = Environment::getDataDir() + "/meshes/" + path;
   if (meshCache.find(path) != meshCache.end()) {
     return meshCache.at(path);
   }

--- a/source/assets/shader/ShaderLoader.cpp
+++ b/source/assets/shader/ShaderLoader.cpp
@@ -9,7 +9,7 @@ namespace glPortal {
 std::map<std::string, Shader> ShaderLoader::shaderCache = { };
 
 Shader ShaderLoader::getShader(std::string path) {
-  path = Environment::getDataDir() + "shaders/" + path;
+  path = Environment::getDataDir() + "/shaders/" + path;
   if(shaderCache.find(path) != shaderCache.end()) {
     return shaderCache.at(path);
   }
@@ -41,6 +41,9 @@ Shader ShaderLoader::getShader(std::string path) {
 
 int ShaderLoader::loadShader(std::string path, GLenum type) {
   std::ifstream file(path.c_str());
+  if (not file.is_open()) {
+    std::cout << "Could not find file" << path << std::endl;
+  }
   std::string str;
   std::string file_contents;
   while (std::getline(file, str)) {

--- a/source/assets/text/FontLoader.cpp
+++ b/source/assets/text/FontLoader.cpp
@@ -15,7 +15,7 @@ namespace glPortal {
 std::map<std::string, Font> FontLoader::fontCache = {};
 
 Font FontLoader::getFont(std::string name) {
-  std::string path = Environment::getDataDir() + "fonts/" + name + ".txt";
+  std::string path = Environment::getDataDir() + "/fonts/" + name + ".txt";
   if(fontCache.find(path) != fontCache.end()) {
     return fontCache.at(path);
   }

--- a/source/assets/texture/TextureLoader.cpp
+++ b/source/assets/texture/TextureLoader.cpp
@@ -12,7 +12,7 @@ namespace glPortal {
 std::map<std::string, Texture> TextureLoader::textureCache = {};
 
 Texture TextureLoader::getTexture(std::string path) {
-  path = Environment::getDataDir() + "textures/" + path;
+  path = Environment::getDataDir() + "/textures/" + path;
   if(textureCache.find(path) != textureCache.end()) {
     return textureCache.at(path);
   }


### PR DESCRIPTION
Running the program can now work with paths that are like this:
./data
instead of requiring an appended slash like this:
./data/

My natural inclination was to do it like the first example, so I figured I'd get it working like that.
Also, this is my first time doing a pull request, so feel free to let me know if I've done something wrong.