### PR TITLE
Fixing includes for SDL

### DIFF
--- a/source/Player.cpp
+++ b/source/Player.cpp
@@ -5,7 +5,7 @@
 #include <Input.hpp>
 #include <Player.hpp>
 #include <SDL2/SDL_mouse.h>
-#include <SDL.h>
+#include <SDL2/SDL_keyboard.h>
 #include <World.hpp>
 #include <cmath>
 


### PR DESCRIPTION
This doesn't build for me without this change.
It's just a guess but this file probably isn't using
both SDL1.2 and SDL2 at the same time, which I think is
where SDL.h is from