### PR TITLE
Fix Windows compilation

### DIFF
--- a/source/Portal.cpp
+++ b/source/Portal.cpp
@@ -1,6 +1,8 @@
+#define _USE_MATH_DEFINES
 #include "Portal.hpp"
 
 #include <algorithm>
+
 #include <cmath>
 
 #include <assets/model/MeshLoader.hpp>

--- a/source/engine/core/math/Vector4f.hpp
+++ b/source/engine/core/math/Vector4f.hpp
@@ -1,6 +1,7 @@
 #ifndef VECTOR4F_HPP
 #define VECTOR4F_HPP
 
+#define _USE_MATH_DEFINES
 #include <cmath>
 #include <string>
 


### PR DESCRIPTION
Defines `_USE_MATH_DEFINES` so that `M_PI` is defined in `<cmath>`