### PR TITLE
Draw os cursor based on what config indicates

### DIFF
--- a/source/Game.cpp
+++ b/source/Game.cpp
@@ -33,6 +33,13 @@ Game::Game() :
   closed(false),
   config(Environment::getConfig()){
   window.create("GlPortal");
+  
+  if(config.cursorVisibility) {
+    window.unlockMouse();
+  }
+  else {
+    window.lockMouse();
+  }
 
   try {
     SoundManager::init();


### PR DESCRIPTION
Following up on the change [fdc708454fc791519ccdd1fafe3804490737f9f9](https://github.com/GlPortal/RadixEngine/commit/fdc708454fc791519ccdd1fafe3804490737f9f9) at RadixEngine branch the os cursor will be drawn based on what the `config.cursorVisibility` indicates.

You can set the `config.cursorVisibility` at runtime before the window is created or simply pass
 `-c `flag to the glPortal executable to force the cursor visibility ON.