### PR TITLE
Initialize the splashCallbackHolder in GameState::init. 

### DIFF
--- a/source/GameState.cpp
+++ b/source/GameState.cpp
@@ -17,6 +17,7 @@ void GameState::init(radix::BaseGame &game) {
         game.getWorld()->stateFunctionStack.push(&GameState::handleGameOverScreen);
       });
 
+  splashCallbackHolder = radix::EventDispatcher::CallbackHolder{};
   winCallbackHolder.setStatic();
 }
 


### PR DESCRIPTION
It prevents crashes when loading a new map.