### PR TITLE
Adding section for Mac to COMPILE.md

### DIFF
--- a/COMPILE.md
+++ b/COMPILE.md
@@ -39,6 +39,7 @@ mkdir build && cd build
 cmake .. -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM="mingw32-make"
 ```
 
+
 If you want to profile the source code pass `-DCMAKE_CXX_FLAGS=-pg` to cmake.
 
 If you encounter an error during this step use the

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -39,20 +39,21 @@ mkdir build && cd build
 cmake .. -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM="mingw32-make"
 ```
 
-#### Mac OS X
-```bash
-## install CMake
-brew install Assimp SDL2 SDL2_mixer TinyXML2 Bullet freeimage
-cmake ./;
-```
-
-
 If you want to profile the source code pass `-DCMAKE_CXX_FLAGS=-pg` to cmake.
 
 If you encounter an error during this step use the
 bugtracker https://github.com/GlPortal/glPortal/issues to report an issue.
 
 If the command did not produce an error, you can build the binary by typing in:
+
+
+#### Mac OS X
+
+```bash
+brew install Assimp SDL2 SDL2_mixer TinyXML2 Bullet freeimage
+cmake ./;
+```
+
 
 ### Building
 #### Linux

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -42,7 +42,7 @@ cmake .. -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM="mingw32-make"
 #### Mac OS X
 ```bash
 ## install CMake
-brew install Assimp SDL2 SDL2_mixer TinyXML2 Bullet
+brew install Assimp SDL2 SDL2_mixer TinyXML2 Bullet freeimage
 cmake ./;
 ```
 

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -39,6 +39,13 @@ mkdir build && cd build
 cmake .. -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM="mingw32-make"
 ```
 
+#### Mac OS X
+```bash
+## install CMake
+brew install Assimp SDL2 SDL2_mixer TinyXML2 Bullet
+cmake ./;
+```
+
 
 If you want to profile the source code pass `-DCMAKE_CXX_FLAGS=-pg` to cmake.
 
@@ -57,6 +64,12 @@ make
 ```bash
 mingw32-make
 ```
+
+#### Mac OS X
+```bash
+make
+```
+
 
 ### Running
 If this produces no error you have built the binary and should be able to start GlPortal by typing in:
@@ -83,8 +96,15 @@ cp /mingw64/bin/{libLinearMath,SDL2{,_mixer},libtinyxml2,libgcc_s_seh-1,libstdc+
 mingw32-make run
 ```
 
+
+#### Mac OS X
+```bash
+make run
+```
+
 If you get errors, try to build GlPortal again. If you don't manage to fix the error, use the
 bugtracker https://github.com/GlPortal/glPortal/issues or http://bugs.glportal.de to report what you did, and what error you got.
+
 
 ## Build with docker
 Building with docker is still in early testing and not feature complete. It will make compiling easier in the future.

--- a/COMPILE.md
+++ b/COMPILE.md
@@ -39,6 +39,12 @@ mkdir build && cd build
 cmake .. -G "MSYS Makefiles" -DCMAKE_MAKE_PROGRAM="mingw32-make"
 ```
 
+#### Mac OS X
+
+```bash
+brew install Assimp SDL2 SDL2_mixer TinyXML2 Bullet freeimage
+cmake ./;
+```
 
 If you want to profile the source code pass `-DCMAKE_CXX_FLAGS=-pg` to cmake.
 
@@ -47,13 +53,6 @@ bugtracker https://github.com/GlPortal/glPortal/issues to report an issue.
 
 If the command did not produce an error, you can build the binary by typing in:
 
-
-#### Mac OS X
-
-```bash
-brew install Assimp SDL2 SDL2_mixer TinyXML2 Bullet freeimage
-cmake ./;
-```
 
 
 ### Building


### PR DESCRIPTION
- [x] do we need to mention installing cmake? (1. `brew install cmake`; 2. https://stackoverflow.com/questions/32185079/installing-cmake-with-home-brew)
- [x] `brew-install` missing libraries `CMake` referenced
- [x] FreeImage required during build, issue #125 helped solve it.
- [x] running `make` a few times fixes build
- [ ] `make run` launches, but only black screen shows up. Console shows shader compile errors. ([related](https://stackoverflow.com/questions/31803872/opengl-glsl-shaders-on-mac-does-not-compile)
fix:
```bash
sed -i.backup s/version\ 130/version\ 140/ data/shaders/*.*
```
